### PR TITLE
Fix parser formatting code snippet

### DIFF
--- a/src/main/java/constants/SuccessMessages.java
+++ b/src/main/java/constants/SuccessMessages.java
@@ -35,7 +35,7 @@ public class SuccessMessages {
     public static final String INSERT_SUCCESS = "Inserted code snippet to flashcard.\n" +
             "Question: %s\n" +
             "Answer: %s\n" +
-            "Code Snippet: %s\n";
+            "Code Snippet: \n%s\n";
 
     public static final String CHANGED_ISLEARNED_SUCCESS = "Changed flashcard number %s into %s";
     public static final String SEARCH_SUCCESS = "Flashcards matched: \n%s";

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -161,6 +161,44 @@ public class Parser {
      * @throws FlashCLIArgumentException if the input is invalid or required arguments are missing.
      */
     public static String parseCodeSnippet(String codeSnippet) {
-        return codeSnippet;
+        int numIndents = 0;
+        int braceStartIndex = codeSnippet.indexOf("{");
+        int braceEndIndex = codeSnippet.indexOf("}");
+        String output = "";
+        while (braceStartIndex > 0 || braceEndIndex > 0) {
+            boolean addCloseBrace = false;
+            String frontCode;
+            String backCode;
+            if (braceStartIndex > 0) {
+                frontCode = codeSnippet.substring(0, braceStartIndex + "{".length());
+                backCode = codeSnippet.substring(braceStartIndex + "{".length());
+                numIndents += 1;
+            } else if (braceEndIndex > 0) {
+                frontCode = codeSnippet.substring(0, braceEndIndex);
+                backCode = codeSnippet.substring(braceEndIndex + "}".length());
+                numIndents -= 1;
+                addCloseBrace = true;
+            } else {
+                frontCode = "";
+                backCode = "";
+            }
+
+            output += frontCode + "\n";
+            if (numIndents > 0) {
+                for (int i = 0; i < numIndents; i++) {
+                    output += ("   ");
+                }
+            }
+            codeSnippet = backCode;
+            braceStartIndex = codeSnippet.indexOf("{");
+            braceEndIndex = codeSnippet.indexOf("}");
+            if (addCloseBrace) {
+                output += "}";
+            }
+            if (braceEndIndex < 0 && braceStartIndex < 0) {
+                output += backCode;
+            }
+        }
+        return output;
     }
 }

--- a/src/test/java/deck/DeckTest.java
+++ b/src/test/java/deck/DeckTest.java
@@ -469,7 +469,7 @@ public class DeckTest {
         String viewOutput = deck.viewFlashcardQuestion(1);
         assertEquals(1, deck.getFlashcards().size());
         assertEquals(String.format(VIEW_QUESTION_SUCCESS, 1, "What is Java?",
-                "Class Java { void method() {...} }"), viewOutput);
+                "Class Java {\n    void method() {\n      ...\n   } \n}"), viewOutput);
     }
 
     @Test


### PR DESCRIPTION
Parser now formats the code snippet correctly based on the curly braces and indents appropriately before printing it out.